### PR TITLE
Add basic dashboard page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@
 Deutsche Bahn onboard (in train WiFi network) Dashboard.
 
 It uses the local api endpoints, that are available on the trains WiFi network.
+
+## Usage
+
+Open `index.html` in a browser while connected to the train's WiFi network. The page periodically queries
+`/api1/rs/status` and `/api1/rs/tripInfo/trip` to display connection state, speed, location on a map and
+basic trip information.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ICE Portal Dashboard</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+NCD39BFH+XorF2J/3uL7D1ZpmjH8obaN6D+4V5lY=" crossorigin=""/>
+</head>
+<body>
+  <h1>ICE Portal Dashboard</h1>
+  <div class="grid">
+    <div class="card">
+      <h2>Train Info</h2>
+      <ul>
+        <li>Train Type: <span id="trainType">-</span></li>
+        <li>Train Number: <span id="tzn">-</span></li>
+        <li>Series: <span id="series">-</span></li>
+        <li>Wagon Class: <span id="wagonClass">-</span></li>
+        <li>Final Station: <span id="finalStation">-</span></li>
+        <li>Next Stop EVA: <span id="nextStop">-</span></li>
+      </ul>
+    </div>
+    <div class="card">
+      <h2>Status</h2>
+      <ul>
+        <li>Connection: <span id="connection">-</span></li>
+        <li>Internet: <span id="internet">-</span></li>
+        <li>Service Level: <span id="serviceLevel">-</span></li>
+        <li>GPS Status: <span id="gpsStatus">-</span></li>
+      </ul>
+    </div>
+    <div class="card">
+      <h2>Speed</h2>
+      <div class="speed-bar">
+        <div id="speedBar" class="speed-progress"></div>
+      </div>
+      <div id="speedValue" class="speed-value">0 km/h</div>
+    </div>
+    <div class="card">
+      <h2>Location</h2>
+      <div id="map"></div>
+      <div>Lat: <span id="latitude">-</span>, Lon: <span id="longitude">-</span></div>
+    </div>
+  </div>
+  <div class="updated">Last updated: <span id="updated">never</span></div>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j7kGht++KzC+51h31UZ5p4UcQ2C2Ny3aKXpry9A=" crossorigin=""></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,74 @@
+const statusUrl = 'https://iceportal.de/api1/rs/status';
+const tripUrl = 'https://iceportal.de/api1/rs/tripInfo/trip';
+const maxSpeed = 300; // km/h for progress bar
+let map, marker;
+
+function updateStatus(data) {
+  document.getElementById('trainType').textContent = data.trainType ?? '-';
+  document.getElementById('tzn').textContent = data.tzn ?? '-';
+  document.getElementById('series').textContent = data.series ?? '-';
+  document.getElementById('wagonClass').textContent = data.wagonClass ?? '-';
+
+  document.getElementById('connection').textContent = data.connection ? 'Online' : 'Offline';
+  document.getElementById('internet').textContent = data.internet;
+  document.getElementById('serviceLevel').textContent = data.serviceLevel;
+  document.getElementById('gpsStatus').textContent = data.gpsStatus;
+
+  const speed = data.speed || 0;
+  document.getElementById('speedValue').textContent = `${speed.toFixed(1)} km/h`;
+  const percent = Math.min(speed / maxSpeed * 100, 100);
+  document.getElementById('speedBar').style.width = percent + '%';
+
+  document.getElementById('latitude').textContent = data.latitude?.toFixed(5) ?? '-';
+  document.getElementById('longitude').textContent = data.longitude?.toFixed(5) ?? '-';
+
+  if (map && data.latitude && data.longitude) {
+    const latlng = [data.latitude, data.longitude];
+    marker.setLatLng(latlng);
+    map.setView(latlng);
+  }
+}
+
+function updateTrip(data) {
+  const info = data.trip?.stopInfo ?? {};
+  document.getElementById('finalStation').textContent = info.finalStationName ?? '-';
+  document.getElementById('nextStop').textContent = info.actualNext ?? '-';
+}
+
+async function fetchStatus() {
+  try {
+    const res = await fetch(statusUrl);
+    const json = await res.json();
+    updateStatus(json);
+    document.getElementById('updated').textContent = new Date().toLocaleTimeString();
+  } catch (err) {
+    console.error('Status fetch failed', err);
+  }
+}
+
+async function fetchTrip() {
+  try {
+    const res = await fetch(tripUrl);
+    const json = await res.json();
+    updateTrip(json);
+  } catch (err) {
+    console.error('Trip fetch failed', err);
+  }
+}
+
+function initMap() {
+  map = L.map('map').setView([51.0, 9.0], 13);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '© OpenStreetMap'
+  }).addTo(map);
+  marker = L.marker([51.0, 9.0]).addTo(map);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  initMap();
+  fetchStatus();
+  fetchTrip();
+  setInterval(fetchStatus, 10000);
+  setInterval(fetchTrip, 60000);
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,56 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 0;
+  background: #f5f5f5;
+}
+
+h1 {
+  text-align: center;
+  margin: 1rem 0;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+  padding: 0 1rem 1rem;
+}
+
+.card {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.speed-bar {
+  width: 100%;
+  background: #eee;
+  border-radius: 4px;
+  height: 20px;
+  overflow: hidden;
+}
+
+.speed-progress {
+  height: 100%;
+  width: 0%;
+  background: #007bff;
+}
+
+.speed-value {
+  text-align: center;
+  margin-top: 0.5rem;
+  font-size: 1.2rem;
+}
+
+#map {
+  height: 200px;
+}
+
+.updated {
+  text-align: center;
+  padding: 0.5rem;
+  font-size: 0.9rem;
+  color: #555;
+}


### PR DESCRIPTION
## Summary
- Add HTML dashboard skeleton displaying train info, connection status, speed and map location.
- Style dashboard with responsive grid and progress bar for speed.
- Implement JavaScript to periodically fetch status and trip data and update the UI.
