### PR TITLE
Add workflow to publish Docker image to GHCR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set lowercase owner
+        run: echo "OWNER_LC=${OWNER,,}" >> $GITHUB_ENV
+        env:
+          OWNER: ${{ github.repository_owner }}
+
+      - name: Log in to Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ env.OWNER_LC }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: DOCKERFILE
+          push: true
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/db-dash:latest
+            ghcr.io/${{ env.OWNER_LC }}/db-dash:${{ github.run_number }}


### PR DESCRIPTION
## Summary
- build and push Docker image to GHCR on push to main
- tag images with `latest` and incrementing `github.run_number`
- ensure GHCR tags and login use lowercased repository owner

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8fc1672c832ca3f37e1c10455112